### PR TITLE
ADD: productlist 조회 API

### DIFF
--- a/products/tests.py
+++ b/products/tests.py
@@ -1,1 +1,211 @@
-from django.test import TestCase
+from django.test import TestCase, Client
+
+from products.models import Product, Brand, Size, ProductSize
+from biddings.models import Bidding
+from users.models    import User
+
+class ProductListUnitTest(TestCase):
+    def setUp(self):
+        Brand.objects.create(
+            id   = 1,
+            name = 'Nike'
+        )
+        Brand.objects.create(
+            id   = 2,
+            name = 'Adidas'
+        )
+        Size.objects.create(
+            id   = 1,
+            name = '230'
+        )
+        Size.objects.create(
+            id   = 2,
+            name = '240'
+        )
+        User.objects.create(
+            id       = 1,
+            kakao_id = 100,
+            email    = "gusrn015@gmail.com"
+        )
+        Product.objects.create(
+            id            = 1,
+            name          = "Nike Dunk Black",
+            korean_name   = "나이키 덩크 블랙",
+            model_number  = "DD1391-100",
+            color         = "WHITE/BLACK",
+            release_at    = "2021-01-14",
+            retail_price  = "129000",
+            thumbnail_url = "url",
+            brand_id      = 1,
+        )
+        Product.objects.create(
+            id            = 2,
+            name          = "Adidas SuperX",
+            korean_name   = "아디다스 슈퍼 엑스",
+            model_number  = "DO9391-201",
+            color         = "WHITE/BLACK",
+            release_at    = "2019-03-22",
+            retail_price  = "185400",
+            thumbnail_url = "url2",
+            brand_id      = 2,
+        )
+        ProductSize.objects.create(
+            id         = 1,
+            product_id = 1,
+            size_id    = 1
+        )
+        ProductSize.objects.create(
+            id         = 2,
+            product_id = 2,
+            size_id    = 2
+        )
+        Bidding.objects.create(
+            price             = 1000,
+            is_buyer          = True,
+            user_id           = 1,
+            products_sizes_id = 1
+        )
+        Bidding.objects.create(
+            price             = 2000,
+            is_buyer          = False,
+            user_id           = 1,
+            products_sizes_id = 2
+        )
+
+    def tearDown(self):
+        Product.objects.all().delete()
+        Brand.objects.all().delete()
+        Size.objects.all().delete()
+        ProductSize.objects.all().delete()
+        Bidding.objects.all().delete()
+    
+    def test_productlistview_get_success(self):
+        client = Client()
+        response = client.get('/products')
+        
+        result = [
+            {
+                "id"            : 1,
+                "brand"         : "Nike",
+                "name"          : "Nike Dunk Black",
+                "korean_name"   : "나이키 덩크 블랙",
+                "price"         : 1000,
+                "thumbnail_url" : "url"
+            },
+            {
+                "id"            : 2,
+                "brand"         : "Adidas",
+                "name"          : "Adidas SuperX",
+                "korean_name"   : "아디다스 슈퍼 엑스",
+                "price"         : 0,
+                "thumbnail_url" : "url2"
+            }
+        ]
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"result" : result})
+
+    def test_productlistview_get_brand_filter_success(self):
+        client = Client()
+        response = client.get('/products?brand=1')
+        
+        result = [
+            {
+                "id"            : 1,
+                "brand"         : "Nike",
+                "name"          : "Nike Dunk Black",
+                "korean_name"   : "나이키 덩크 블랙",
+                "price"         : 1000,
+                "thumbnail_url" : "url"
+            }
+        ]
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"result" : result})
+
+    def test_productlistview_get_size_filter_success(self):
+        client = Client()
+        response = client.get('/products?size=2')
+        
+        result = [
+            {
+                "id"            : 2,
+                "brand"         : "Adidas",
+                "name"          : "Adidas SuperX",
+                "korean_name"   : "아디다스 슈퍼 엑스",
+                "price"         : 0,
+                "thumbnail_url" : "url2"
+            }
+        ]
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"result" : result})
+
+    def test_productlistview_get_order_success(self):
+        client = Client()
+        response = client.get('/products?sort=highest')
+        
+        result = [
+            {
+                "id"            : 2,
+                "brand"         : "Adidas",
+                "name"          : "Adidas SuperX",
+                "korean_name"   : "아디다스 슈퍼 엑스",
+                "price"         : 2000,
+                "thumbnail_url" : "url2"
+            }
+        ]
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"result" : result})
+
+class FilterBarUnitTest(TestCase):
+    def setUp(self):
+        Brand.objects.create(
+            id   = 1,
+            name = 'Nike'
+        )
+        Brand.objects.create(
+            id   = 2,
+            name = 'Adidas'
+        )
+        Size.objects.create(
+            id   = 1,
+            name = '230'
+        )
+        Size.objects.create(
+            id   = 2,
+            name = '240'
+        )
+
+    def tearDown(self):
+        Brand.objects.all().delete()
+        Size.objects.all().delete()
+
+    def test_filterbarview_get_success(self):
+        client = Client()
+        response = client.get('/products/filter')
+        
+        result = {
+            "brand" : [
+                {
+                    "id"   : 1,
+                    "name" : "Nike"
+                },
+                {
+                    "id"   : 2,
+                    "name" : "Adidas"
+                }],
+            "size" : [
+                {
+                    "id"   : 1,
+                    "name" : "230"
+                },
+                {
+                    "id"   : 2,
+                    "name" : "240"
+                }]
+            }
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"result" : result})

--- a/products/urls.py
+++ b/products/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from products.views import ProductListView, FilterBarView
+
+urlpatterns = [
+    path('', ProductListView.as_view()),
+    path('/filter', FilterBarView.as_view()),
+    
+]

--- a/products/views.py
+++ b/products/views.py
@@ -1,1 +1,73 @@
-from django.shortcuts import render
+from django.http      import JsonResponse
+from django.views     import View
+from django.db.models import Q, Min, Max
+
+from products.models import Product, Brand, Size
+
+class ProductListView(View):
+    def get(self, request):
+        brands   = request.GET.getlist('brand', None)
+        sizes    = request.GET.getlist('size', None)
+        order    = request.GET.get('order', 'recent')
+        is_buyer = request.GET.get('is_buyer', 1)
+
+        is_buyer = bool(int(is_buyer))
+
+        filtering = Q()
+
+        if brands:
+            filtering &= Q(brand__id__in = brands)
+
+        if sizes:
+            filtering &= Q(sizes__id__in = sizes)
+
+        if is_buyer:
+            filtering &= Q(productsize__bidding__is_buyer = True)
+            products   = Product.objects\
+                                .annotate(price=Min("productsize__bidding__price"))\
+                                .filter(filtering)
+
+        if not is_buyer:
+            filtering &= Q(productsize__bidding__is_buyer = False)
+            products   = Product.objects\
+                                .annotate(price=Max("productsize__bidding__price"))\
+                                .filter(filtering)
+
+        ordering_field = {
+            "recent"     : "-release_at",
+            "low_price"  : "price",
+            "high_price" : "-price"
+        }
+        
+        ordering = ordering_field.get(order, "-release_at")
+
+        result = [{
+                "id"            : product.id,
+                "brand"         : product.brand.name,
+                "name"          : product.name,
+                "korean_name"   : product.korean_name,
+                "price"         : int(product.price),
+                "thumbnail_url" : product.thumbnail_url
+            } for product in products.order_by(ordering)]
+
+        return JsonResponse({"result" : result}, status=200)
+
+class FilterBarView(View):
+    def get(self, request):
+        brands = Brand.objects.all()
+        sizes  = Size.objects.all()
+
+        result = {
+            "brand" : [
+                {
+                    "id"   : brand.id,
+                    "name" : brand.name
+                } for brand in brands],
+            "size"  : [
+                {
+                    "id"   : size.id, 
+                    "name" : size.name
+                } for size in sizes]
+            }
+
+        return JsonResponse({"result" : result}, status=200)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ django-cors-headers == 3.10.1
 mysqlclient         == 2.1.0
 PyJWT               == 2.3.0
 PyMySQL             == 1.0.2
+requests            == 2.27.1

--- a/sucream/urls.py
+++ b/sucream/urls.py
@@ -2,4 +2,5 @@ from django.urls import path, include
 
 urlpatterns = [
     path('users', include('users.urls')),
+    path('products', include('products.urls')),
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -1,7 +1,6 @@
 import requests, jwt
 
 from django.http.response import JsonResponse
-from django.conf          import settings
 from django.views         import View
 
 from my_settings       import SECRET_KEY, ALGORITHM


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 메인,제품 페이지 구성에 필요한 제품 정보 리스트와 브랜드, 사이즈 필터링 정보를 응답하는 API 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 제품 리스트 응답
- 최초 메인 페이지에서 전체 제품 리스트를 호출 > 응답
- query parameter로 전달된 필터링, 정렬 정보에 따라서 제품 리스트 응답

2. 필터링되는 정보 리스트 응답
- brand, size 두가지 항목에 대해서 DB에 등록된 정보 호출하여, 전부 응답

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- Unit test 코드 작성을 통한 기능 점검
- Q 객체와 언더스코어(_)두개 사용을 통한 외부 테이블 참조

<br />

## :: 기타 질문 및 특이 사항
- 너무 억지로 짜맞춘 느낌이 듭니다.... 어떻게 해야할까요
